### PR TITLE
Pypdf

### DIFF
--- a/myapp/pdf_generator/pdf_generator.py
+++ b/myapp/pdf_generator/pdf_generator.py
@@ -2,7 +2,7 @@ import io
 from collections import OrderedDict
 from io import StringIO
 import cairosvg
-from PyPDF2 import PdfMerger
+from pypdf import PdfWriter, PdfReader
 import locale
 from ..models import (
     Invoice,
@@ -165,12 +165,13 @@ class PDFGenerator:
         return full_reference
 
     def generate_pdf(self, invoices: list[Invoice]) -> io.BytesIO:
-        merger = PdfMerger()
+        writer = PdfWriter()
         for invoice in invoices:
-            merger.append(self.__generate_pdf__(invoice))
+            reader = PdfReader(self.__generate_pdf__(invoice))
+            writer.append(reader)
 
         result = io.BytesIO()
-        merger.write(result)
+        writer.write(result)
         result.seek(0)
 
         return result
@@ -361,7 +362,7 @@ class PDFGenerator:
         return pos
 
     def generate_pdf_blank(self, subscription: Subscription):
-        merger = PdfMerger()
+        writer = PdfWriter()
 
         for order, subscription_type in enumerate(
             OrderedDict(SubscriptionTypeEnum.choices)
@@ -446,9 +447,10 @@ class PDFGenerator:
 
                 dwg.write(svg_buffer)
 
-                merger.append(self.__svg2Pdf__(svg_buffer))
+                pdf_reader = PdfReader(self.__svg2Pdf__(svg_buffer))
+                writer.append(pdf_reader)
         result = io.BytesIO()
-        merger.write(result)
+        writer.write(result)
         result.seek(0)
 
         return result

--- a/myapp/tests/test_pdfs.py
+++ b/myapp/tests/test_pdfs.py
@@ -2,7 +2,7 @@ import io
 
 from myapp.models import Subscription, Invoice, Member, MemberSubscription
 from myapp.tests.test_common import LoggedInTestCase
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 
 
 class PdfsTestCase(LoggedInTestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "python-dotenv",
   "qrbill",
   "cairosvg",
-  "PyPDF2",
+  "pypdf>=3.9.0",
   "pandas",
   "xlsxwriter",
   "django-debug-toolbar",

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -60,7 +60,7 @@ pycamt==1.0.1
     # via myproject (pyproject.toml)
 pycparser==2.22
     # via cffi
-pypdf2==3.0.1
+pypdf==5.5.0
     # via myproject (pyproject.toml)
 pyproject-hooks==1.2.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ pycamt==1.0.1
     # via myproject (pyproject.toml)
 pycparser==2.22
     # via cffi
-pypdf2==3.0.1
+pypdf==5.5.0
     # via myproject (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via pandas


### PR DESCRIPTION
It is recommended to upgrade to pypdf>=3.9.0. PyPDF2 users should migrate to pypdf.